### PR TITLE
Added more options for more flexibility "out of the box"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
 
 ![input](https://raw.githubusercontent.com/keegandonley/input-deno/master/.github/input.png)
@@ -6,21 +5,24 @@
 </div>
 
 # Input-Deno
+
 ![Tests](https://github.com/keegandonley/input-deno/workflows/Tests/badge.svg)
 
 Used to get command line input from the user
 
 ## Usage
+
 ```javascript
 import InputLoop from 'https://raw.githubusercontent.com/Yazidn/input-deno/master/install/input.ts';
 ```
 
 ## Choose
+
 Returns an array indicating which index was selected
 
 ```javascript
 const input = new InputLoop();
-const accepting = await input.choose(["Accepting node", "Non-accepting node"]);
+const accepting = await input.choose(['Accepting node', 'Non-accepting node']);
 
 // output:
 
@@ -41,31 +43,36 @@ interface Preferences {
 	lastOptionClose?: boolean,
 	choice?: string | number,
 	displayInline?: boolean, // if true, display all options in the same line
-	inlineSpacing?: number, // number of spaces between inline options, default is 2
-	indexStyle?: string[],
-	dividerUp?: boolean,
-	dividerBottom?: boolean
-	dividerLength?: number
-	dividerChar?: string,
-	dividerPadding?: boolean
+	inlineSeparator?: string, // takes a string, e.g. '|', pipe would be set as a separator instead of spaces.
+	inlineSpacing?: number, // number of spaces between inline options, default is 2 (Only works when inlineSeparator is NOT set.)
+	indexStyle?: string[], // an array of 2 strings to surround the index. e.g. ['[', ']']. Can be any string
+	dividerUp?: boolean, // Show a divider above the options
+	dividerBottom?: boolean // Show a divider below the options
+	dividerLength?: number // Set a custom length for the divider
+	dividerChar?: string, // Set a custom character for the divider, default is '-'
+	dividerPadding?: boolean // Add space (new line) between dividers and options. 
 }
 
 // Example
 const input = new InputLoop();
 await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
-	lastOptionClose: true,
-	displayInline: true,
-	indexStyle: [
-		'( ', ' )'
-	],
-	inlineSpacing: 5
+        lastOptionClose: true,
+        displayInline: true,
+        indexStyle: ['{ ', ' }'],
+        dividerBottom: true,
+		dividerLength: 127,
+		inlineSeparator: ' | '
 });
 
 // Output
-// ( 0 ) Option 1     ( 1 ) Option 2     ( 2 ) Option 3     ( 3 ) Option 4     ( 4 ) Option 5     ( 5 ) Option 6     ( 6 ) Quit
+
+// { 0 } Option 1  |  { 1 } Option 2  |  { 2 } Option 3  |  { 3 } Option 4  |  { 4 } Option 5  |  { 5 } Option 6  |  { 6 } Quit  |  
+// -------------------------------------------------------------------------------------------------------------------------------
+
 ```
 
 ## Question
+
 Ask a single question
 
 ```javascript
@@ -81,6 +88,7 @@ const nodeName = await input.question('Enter the label for the node:');
 ```
 
 Skip the newline after printing the question:
+
 ```javascript
 const input = new InputLoop();
 const nodeName = await input.question('Enter the label for the node:', false);
@@ -94,55 +102,60 @@ const nodeName = await input.question('Enter the label for the node:', false);
 ```
 
 ## Looping
+
 Control an input loop which continues reprompting until terminated
 
 #### Automatic Looping:
+
 Passing `true` as the second argument will automatically end the iteration of the last option is selected.
 
 ```javascript
 const input = new InputLoop();
-const mainQuestions = ["Add a node", "Add an edge", "Set starting node", "Evaluate a string", "Quit"];
+const mainQuestions = ['Add a node', 'Add an edge', 'Set starting node', 'Evaluate a string', 'Quit'];
 
 while (!input.done) {
-	const result = await input.choose(mainQuestions, true);
+    const result = await input.choose(mainQuestions, true);
 
-	// Business logic...
+    // Business logic...
 }
 ```
 
 #### Manual Looping:
+
 ```javascript
 const input = new InputLoop();
-const mainQuestions = ["Add a node", "Add an edge", "Set starting node", "Evaluate a string", "Quit"];
+const mainQuestions = ['Add a node', 'Add an edge', 'Set starting node', 'Evaluate a string', 'Quit'];
 
 while (!input.done) {
-	const result = await input.choose(mainQuestions);
+    const result = await input.choose(mainQuestions);
 
-	// Business logic...
+    // Business logic...
 
-	if (result[mainQuestions.length - 1]) {
-		input.close();
-	}
+    if (result[mainQuestions.length - 1]) {
+        input.close();
+    }
 }
 ```
 
 ## Repeat
+
 Repeat the previous question
 
 ```javascript
 const input = new InputLoop();
-const mainQuestions = ["Add a node", "Add an edge", "Set starting node", "Evaluate a string", "Quit"];
+const mainQuestions = ['Add a node', 'Add an edge', 'Set starting node', 'Evaluate a string', 'Quit'];
 
 let result = await input.choose(mainQuestions);
 
 while (!(result[0] || result[1])) {
-	result = input.repeat();
+    result = input.repeat();
 }
-
 ```
 
 ## Testing
+
 Deno tests can be run using:
+
 ```
 make test
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ const accepting = await input.choose(["Accepting node", "Non-accepting node"]);
 // [false, true]
 ```
 
+You can further customize the behavior of choose() by passing an object of perferences as a second argument.
+All preferences are optional, as shows in the interface below.
+
+```javascript
+export interface Preferences {
+	lastOptionClose?: boolean,
+	choice?: string | number,
+	
+	// Breakpoint
+	breakPoint?: number,
+	
+	// Index
+	indexStyle?: string,
+	
+	// Divider
+	dividerUp?: boolean,
+	dividerBottom?: boolean
+	dividerStyle?: string
+}
+
+const input = new InputLoop();
+const accepting = await input.choose(["Accepting node", "Non-accepting node"], {
+	true
+});
+```
+
 ## Question
 Ask a single question
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Used to get command line input from the user
 
 ```javascript
 import InputLoop from 'https://raw.githubusercontent.com/Yazidn/input-deno/master/install/input.ts';
+
+// Example
+const input = new InputLoop();
+await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
+	lastOptionClose: true,
+	displayInline: true,
+	indexStyle: ['{ ', ' }'],
+	dividerBottom: true,
+	dividerLength: 127,
+	inlineSeparator: ' | '
+});
+
+// Output
+
+// { 0 } Option 1  |  { 1 } Option 2  |  { 2 } Option 3  |  { 3 } Option 4  |  { 4 } Option 5  |  { 5 } Option 6  |  { 6 } Quit  |  
+// -------------------------------------------------------------------------------------------------------------------------------
 ```
 
 ## Choose
@@ -35,8 +51,8 @@ const accepting = await input.choose(['Accepting node', 'Non-accepting node']);
 // [false, true]
 ```
 
-You can further customize the behavior of choose() by passing an object of perferences as a second argument.
-All preferences are optional, as shows in the interface below.
+You can further customize the behavior of the choose method by passing an object of perferences as a second argument.
+All preferences are optional, as shown in the interface below.
 
 ```javascript
 interface Preferences {
@@ -52,23 +68,6 @@ interface Preferences {
 	dividerChar?: string, // Set a custom character for the divider, default is '-'
 	dividerPadding?: boolean // Add space (new line) between dividers and options. 
 }
-
-// Example
-const input = new InputLoop();
-await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
-        lastOptionClose: true,
-        displayInline: true,
-        indexStyle: ['{ ', ' }'],
-        dividerBottom: true,
-		dividerLength: 127,
-		inlineSeparator: ' | '
-});
-
-// Output
-
-// { 0 } Option 1  |  { 1 } Option 2  |  { 2 } Option 3  |  { 3 } Option 4  |  { 4 } Option 5  |  { 5 } Option 6  |  { 6 } Quit  |  
-// -------------------------------------------------------------------------------------------------------------------------------
-
 ```
 
 ## Question

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 Used to get command line input from the user
 
+## Install
+```javascript
+import InputLoop from '';
+```
+
 ## Choose
 Returns an array indicating which index was selected
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Used to get command line input from the user
 
 ## Install
 ```javascript
-import InputLoop from '';
+import InputLoop from 'https://raw.githubusercontent.com/Yazidn/input-deno/master/install/input.ts';
 ```
 
 ## Choose

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Used to get command line input from the user
 
-## Install
+## Usage
 ```javascript
 import InputLoop from 'https://raw.githubusercontent.com/Yazidn/input-deno/master/install/input.ts';
 ```
@@ -37,26 +37,32 @@ You can further customize the behavior of choose() by passing an object of perfe
 All preferences are optional, as shows in the interface below.
 
 ```javascript
-export interface Preferences {
+interface Preferences {
 	lastOptionClose?: boolean,
 	choice?: string | number,
-	
-	// Breakpoint
-	breakPoint?: number,
-	
-	// Index
-	indexStyle?: string,
-	
-	// Divider
+	displayInline?: boolean, // if true, display all options in the same line
+	inlineSpacing?: number, // number of spaces between inline options, default is 2
+	indexStyle?: string[],
 	dividerUp?: boolean,
 	dividerBottom?: boolean
-	dividerStyle?: string
+	dividerLength?: number
+	dividerChar?: string,
+	dividerPadding?: boolean
 }
 
+// Example
 const input = new InputLoop();
-const accepting = await input.choose(["Accepting node", "Non-accepting node"], {
-	true
+await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
+	lastOptionClose: true,
+	displayInline: true,
+	indexStyle: [
+		'( ', ' )'
+	],
+	inlineSpacing: 5
 });
+
+// Output
+// ( 0 ) Option 1     ( 1 ) Option 2     ( 2 ) Option 3     ( 3 ) Option 4     ( 4 ) Option 5     ( 5 ) Option 6     ( 6 ) Quit
 ```
 
 ## Question

--- a/cli.ts
+++ b/cli.ts
@@ -3,7 +3,15 @@ import Input from './index.ts';
 const input = new Input();
 
 while (!input.done) {
-	await input.question("Say something: ", false);
-	await input.question("Say something with newline:");
-	await input.choose(['Option 1', 'Option 2', 'Quit'], true);
+    await input.question('Say something: ', false);
+    await input.question('Say something with newline:');
+    await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
+        lastOptionClose: true,
+        displayInline: true,
+        indexStyle: ['', ') '],
+        dividerTop: true,
+        dividerBottom: true,
+		dividerPadding: true,
+		inlineSpacing: 8
+    });
 }

--- a/cli.ts
+++ b/cli.ts
@@ -5,4 +5,5 @@ const input = new Input();
 while (!input.done) {
 	await input.question("Say something: ", false);
 	await input.question("Say something with newline:");
+	await input.choose(['Option 1', 'Option 2', 'Quit'], true);
 }

--- a/cli.ts
+++ b/cli.ts
@@ -8,10 +8,12 @@ while (!input.done) {
     await input.choose(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6', 'Quit'], {
         lastOptionClose: true,
         displayInline: true,
-        indexStyle: ['', ') '],
+        indexStyle: ['{ ', ' }'],
         dividerTop: true,
         dividerBottom: true,
 		dividerPadding: true,
-		inlineSpacing: 8
+		dividerLength: 120,
+		inlineSpacing: 8,
+		inlineSeparator: ' | '
     });
 }

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,157 +1,190 @@
 import inputLoop from './index.ts';
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
 
-Deno.test("Initialize with no args", () => {
-  const loop = new inputLoop();
-  assertEquals(loop.done, false);
+Deno.test('Initialize with no args', () => {
+    const loop = new inputLoop();
+    assertEquals(loop.done, false);
 });
 
-Deno.test("Should not be done", () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  assertEquals(loop.done, false);
+Deno.test('Should not be done', () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    assertEquals(loop.done, false);
 });
 
-Deno.test("Should be marked as done", () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  loop.close();
-  assertEquals(loop.done, true);
+Deno.test('Should be marked as done', () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    loop.close();
+    assertEquals(loop.done, true);
 });
 
-Deno.test("Should choose an answer (number)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 2);
-  assertEquals(result, [false, false, true]);
+Deno.test('Should choose an answer (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: 2,
+    });
+    assertEquals(result, [false, false, true]);
 });
 
-Deno.test("Should choose an answer (string)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2');
-  assertEquals(result, [false, false, true]);
+Deno.test('Should choose an answer (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: '2',
+    });
+    assertEquals(result, [false, false, true]);
 });
 
 // Added to test issue https://github.com/keegandonley/input-deno/issues/3
-Deno.test("Should choose an answer (string | CRLF) ", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2\r\n');
-  assertEquals(result, [false, false, true]);
+Deno.test('Should choose an answer (string | CRLF) ', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: '2\r\n',
+    });
+    assertEquals(result, [false, false, true]);
 });
 
-Deno.test("Should not choose an answer (number)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 3);
-  assertEquals(result, [false, false, false]);
+Deno.test('Should not choose an answer (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: 3,
+    });
+    assertEquals(result, [false, false, false]);
 });
 
-Deno.test("Should not choose an answer (string)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '3');
-  assertEquals(result, [false, false, false]);
+Deno.test('Should not choose an answer (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: '3',
+    });
+    assertEquals(result, [false, false, false]);
 });
 
-Deno.test("Should run repeat on choose success (number)", async () => {
-  const loop = new inputLoop({
-	silent: true,
-	});
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 2);
-  assertEquals(result, [false, false, true]);
-  const result2 = await loop.repeat(2);
-  assertEquals(result2, [false, false, true]);
+Deno.test('Should run repeat on choose success (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: 2,
+    });
+    assertEquals(result, [false, false, true]);
+    const result2 = await loop.repeat(2);
+    assertEquals(result2, [false, false, true]);
 });
 
-Deno.test("Should run repeat on choose success (string)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2');
-  assertEquals(result, [false, false, true]);
-  const result2 = await loop.repeat('2');
-  assertEquals(result2, [false, false, true]);
+Deno.test('Should run repeat on choose success (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: '2',
+    });
+    assertEquals(result, [false, false, true]);
+    const result2 = await loop.repeat('2');
+    assertEquals(result2, [false, false, true]);
 });
 
-Deno.test("Should run repeat on choose fail (number)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 3);
-  assertEquals(result, [false, false, false]);
-  const result2 = await loop.repeat(3);
-  assertEquals(result2, [false, false, false]);
+Deno.test('Should run repeat on choose fail (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: 3,
+    });
+    assertEquals(result, [false, false, false]);
+    const result2 = await loop.repeat(3);
+    assertEquals(result2, [false, false, false]);
 });
 
-Deno.test("Should run repeat on choose fail (string)", async () => {
-  const loop = new inputLoop({
-	  silent: true,
-  });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, "3");
-  assertEquals(result, [false, false, false]);
-  const result2 = await loop.repeat("3");
-  assertEquals(result2, [false, false, false]);
+Deno.test('Should run repeat on choose fail (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: false,
+        choice: '3',
+    });
+    assertEquals(result, [false, false, false]);
+    const result2 = await loop.repeat('3');
+    assertEquals(result2, [false, false, false]);
 });
 
-Deno.test("Should answer a question (number)", async () => {
-  const loop = new inputLoop({
-    silent: true,
-  });
-  const result = await loop.question("Please answer the question", true, 2);
-  assertEquals(result, '2');
+Deno.test('Should answer a question (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.question('Please answer the question', true, 2);
+    assertEquals(result, '2');
 });
 
-Deno.test("Should answer a question (string)", async () => {
-  const loop = new inputLoop({
-    silent: true,
-  });
-  const result = await loop.question("Please answer the question", true, "Hello!");
-  assertEquals(result, "Hello!");
+Deno.test('Should answer a question (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.question('Please answer the question', true, 'Hello!');
+    assertEquals(result, 'Hello!');
 });
 
-Deno.test("Should answer a question (string | no newline)", async () => {
-  const loop = new inputLoop({
-    silent: true,
-  });
-  const result = await loop.question("Please answer the question", false, "Hello!");
-  assertEquals(result, "Hello!");
+Deno.test('Should answer a question (string | no newline)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.question('Please answer the question', false, 'Hello!');
+    assertEquals(result, 'Hello!');
 });
 
-Deno.test("Should run repeat on question (string)", async () => {
-  const loop = new inputLoop({
-    silent: true,
-  });
-  const result = await loop.question("Please answer the question", true, "Hello!");
-  assertEquals(result, "Hello!");
-  const result2 = await loop.repeat("Hello Again!");
-  assertEquals(result2, 'Hello Again!')
+Deno.test('Should run repeat on question (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    const result = await loop.question('Please answer the question', true, 'Hello!');
+    assertEquals(result, 'Hello!');
+    const result2 = await loop.repeat('Hello Again!');
+    assertEquals(result2, 'Hello Again!');
 });
 
-Deno.test("Should close automatically (string)", async () => {
-	const loop = new inputLoop({
-		silent: true,
-	});
-	assertEquals(loop.done, false);
-	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, "2");
-	assertEquals(result, [false, false, true]);
-	assertEquals(loop.done, true);
+Deno.test('Should close automatically (string)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    assertEquals(loop.done, false);
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: true,
+        choice: '2',
+    });
+    assertEquals(result, [false, false, true]);
+    assertEquals(loop.done, true);
 });
 
-Deno.test("Should close automatically (number)", async () => {
-	const loop = new inputLoop({
-		silent: true,
-	});
-	assertEquals(loop.done, false);
-	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, 2);
-	assertEquals(result, [false, false, true]);
-	assertEquals(loop.done, true);
+Deno.test('Should close automatically (number)', async () => {
+    const loop = new inputLoop({
+        silent: true,
+    });
+    assertEquals(loop.done, false);
+    const result = await loop.choose(['Option 1', 'Option 2', 'Option 3'], {
+        lastOptionClose: true,
+        choice: 2,
+    });
+    assertEquals(result, [false, false, true]);
+    assertEquals(loop.done, true);
 });

--- a/index.ts
+++ b/index.ts
@@ -73,52 +73,65 @@ export default class InputLoop {
      * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
      */
     public choose = async (options: string[], preferences: Preferences = {}): Promise<boolean[]> => {
+        let {
+            choice,
+            lastOptionClose,
+            displayInline,
+            inlineSpacing,
+            inlineSeparator,
+            indexStyle,
+            dividerTop,
+            dividerBottom,
+            dividerChar,
+            dividerLength,
+            dividerPadding,
+        }: Preferences = preferences;
+
         // Index Styling
         let indexStyleLeft = '[';
         let indexStyleRight = ']';
 
-        if (preferences.indexStyle) {
-            indexStyleLeft = preferences.indexStyle[0];
-            indexStyleRight = preferences.indexStyle[1];
+        if (indexStyle) {
+            indexStyleLeft = indexStyle[0];
+            indexStyleRight = indexStyle[1];
         }
 
         // Spacing
         this.out.newline();
 
         // Divider Up
-        if (preferences.dividerTop)
-            this.out.divider(preferences.dividerLength || undefined, preferences.dividerChar || undefined);
-        if (preferences.dividerPadding) this.out.newline();
+        if (dividerTop) this.out.divider(dividerLength || undefined, dividerChar || undefined);
+        if (dividerPadding) this.out.newline();
+
+        // Separator
+        let separator = inlineSeparator ? ` ${inlineSeparator} ` : ' '.repeat(inlineSpacing || 2);
 
         // Options
         options.forEach((option: string, index: number) => {
-            if (preferences.displayInline)
-                this.out.print(
-                    `${indexStyleLeft}${index}${indexStyleRight} ${option}${' '.repeat(preferences.inlineSpacing || 2)}`
-                );
+            if (displayInline) this.out.print(`${indexStyleLeft}${index}${indexStyleRight} ${option}${separator}`);
             else this.out.print(`${indexStyleLeft}${index}${indexStyleRight} ${option}`, true);
         });
 
         // Divider Bottom
-        if (preferences.dividerBottom) {
+        if (dividerBottom) {
             this.out.newline();
-            if (preferences.dividerPadding) this.out.newline();
-            this.out.divider(preferences.dividerLength || undefined, preferences.dividerChar || undefined);
+            if (dividerPadding) this.out.newline();
+            this.out.divider(dividerLength || undefined, dividerChar || undefined);
         }
 
         // Allow passing a result directly instead of prompting for it.
         // Mostly used for testing without the need for interactive input
 
         let result: string;
-        if (preferences.choice !== undefined) {
-            result = this.cleanInput(this.coerceChoice(preferences.choice));
+        if (choice !== undefined) {
+            result = this.cleanInput(this.coerceChoice(choice));
         } else {
             result = await this.read();
         }
 
-        this.history.save(options, ACTIONS.CHOOSE, preferences.lastOptionClose ?? false);
+        this.history.save(options, ACTIONS.CHOOSE, lastOptionClose ?? false);
 
-        if (preferences.lastOptionClose && result === String(options.length - 1)) {
+        if (lastOptionClose && result === String(options.length - 1)) {
             this.close();
         }
 

--- a/index.ts
+++ b/index.ts
@@ -73,12 +73,38 @@ export default class InputLoop {
      * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
      */
     public choose = async (options: string[], preferences: Preferences = {}): Promise<boolean[]> => {
+        // Index Styling
+        let indexStyleLeft = '[';
+        let indexStyleRight = ']';
+
+        if (preferences.indexStyle) {
+            indexStyleLeft = preferences.indexStyle[0];
+            indexStyleRight = preferences.indexStyle[1];
+        }
+
+        // Spacing
         this.out.newline();
 
+        // Divider Up
+        if (preferences.dividerTop)
+            this.out.divider(preferences.dividerLength || undefined, preferences.dividerChar || undefined);
+        if (preferences.dividerPadding) this.out.newline();
+
+        // Options
         options.forEach((option: string, index: number) => {
-            if (options.length < 7) this.out.print(`[${index}] ${option}  `);
-            else this.out.print(`${index}: ${option}`, true);
+            if (preferences.displayInline)
+                this.out.print(
+                    `${indexStyleLeft}${index}${indexStyleRight} ${option}${' '.repeat(preferences.inlineSpacing || 2)}`
+                );
+            else this.out.print(`${indexStyleLeft}${index}${indexStyleRight} ${option}`, true);
         });
+
+        // Divider Bottom
+        if (preferences.dividerBottom) {
+            this.out.newline();
+            if (preferences.dividerPadding) this.out.newline();
+            this.out.divider(preferences.dividerLength || undefined, preferences.dividerChar || undefined);
+        }
 
         // Allow passing a result directly instead of prompting for it.
         // Mostly used for testing without the need for interactive input

--- a/index.ts
+++ b/index.ts
@@ -1,124 +1,132 @@
-import { IConfig, ACTIONS } from './types.ts';
+import { IConfig, ACTIONS, Preferences } from './types.ts';
 import Printer from './printer.ts';
 import History from './history.ts';
 
 export default class InputLoop {
-	private buf = new Uint8Array(1024);
-	done = false;
-	out = new Printer();
-	history = new History();
+    private buf = new Uint8Array(1024);
+    done = false;
+    out = new Printer();
+    history = new History();
 
-	constructor(args?: IConfig) {
-		this.out = new Printer(args);
-	}
+    constructor(args?: IConfig) {
+        this.out = new Printer(args);
+    }
 
-	private coerceChoice = (value: string | number): string => {
-		if (typeof value === 'number') {
-			return String(value);
-		}
-		return value;
-	}
+    private coerceChoice = (value: string | number): string => {
+        if (typeof value === 'number') {
+            return String(value);
+        }
+        return value;
+    };
 
-	private promisify = (value?: string): Promise<string> => {
-		return new Promise((resolve) => resolve(value));
-	}
+    private promisify = (value?: string): Promise<string> => {
+        return new Promise((resolve) => resolve(value));
+    };
 
-	private cleanInput = (value?: string): string => {
-		return value?.replace('\n', '').replace('\r', '') ?? '';
-	}
+    private cleanInput = (value?: string): string => {
+        return value?.replace('\n', '').replace('\r', '') ?? '';
+    };
 
-	/**
-	 * Repeats the last prompt
-	 * @param {string | number} value value to auto-select
-	 */
-	public repeat = (value?: string | number) => {
-		if (this.history.retrieve().action) {
-			if (this.history.retrieve().action === ACTIONS.CHOOSE) {
-				return this.choose(this.history.retrieve().argument as string[], this.history.retrieve().lastOptionClose, value);
-			}
-			if (this.history.retrieve().action === ACTIONS.QUESTION) {
-				return this.question(this.history.retrieve().argument as string, this.history.retrieve().includeNewline, value);
-			}
-		}
-	}
+    /**
+     * Repeats the last prompt
+     * @param {string | number} value value to auto-select
+     */
+    public repeat = (value?: string | number) => {
+        if (this.history.retrieve().action) {
+            if (this.history.retrieve().action === ACTIONS.CHOOSE) {
+                return this.choose(this.history.retrieve().argument as string[], {
+                    lastOptionClose: this.history.retrieve().lastOptionClose,
+                    choice: value,
+                });
+            }
+            if (this.history.retrieve().action === ACTIONS.QUESTION) {
+                return this.question(
+                    this.history.retrieve().argument as string,
+                    this.history.retrieve().includeNewline,
+                    value
+                );
+            }
+        }
+    };
 
-	/**
-	 * Read input from the console
-	 * @returns {Promise<string>} The value read
-	 */
-	public read = async (): Promise<string> => {
-		return new Promise(async (resolve, reject) => {
-			const n = await Deno.stdin.read(this.buf);
+    /**
+     * Read input from the console
+     * @returns {Promise<string>} The value read
+     */
+    public read = async (): Promise<string> => {
+        return new Promise(async (resolve, reject) => {
+            const n = await Deno.stdin.read(this.buf);
 
-			if (n) {
-				resolve(this.cleanInput(new TextDecoder().decode(this.buf.subarray(0, n))));
-			} else {
-				reject();
-			}
-		});
-	}
+            if (n) {
+                resolve(this.cleanInput(new TextDecoder().decode(this.buf.subarray(0, n))));
+            } else {
+                reject();
+            }
+        });
+    };
 
-	/**
-	 * Prompts the user to choose from a list of options
-	 * @param {string[]} options
-	 * @param {boolean} lastOptionClose Whether selecting the last option in the list should close the loop
-	 * @param {string | number} choice value to auto-select
-	 * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
-	 */
-	public choose = async (options: string[], lastOptionClose?: boolean, choice?: string | number): Promise<boolean[]> => {
-		this.out.newline();
-		options.forEach((option: string, index: number) => {
-			if (options.length < 7) this.out.print(`[${index}] ${option}  `);
-			else this.out.print(`${index}: ${option}`, true);
-		});
-		
-		// Allow passing a result directly instead of prompting for it.
-		// Mostly used for testing without the need for interactive input
+    /**
+     * Prompts the user to choose from a list of options
+     * @param {string[]} options
+     * @param {boolean} lastOptionClose Whether selecting the last option in the list should close the loop
+     * @param {string | number} choice value to auto-select
+     * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
+     */
+    public choose = async (options: string[], preferences: Preferences = {}): Promise<boolean[]> => {
+        this.out.newline();
 
-		let result: string;
-		if (choice !== undefined) {
-			result = this.cleanInput(this.coerceChoice(choice));
-		} else {
-			result = await this.read();
-		}
+        options.forEach((option: string, index: number) => {
+            if (options.length < 7) this.out.print(`[${index}] ${option}  `);
+            else this.out.print(`${index}: ${option}`, true);
+        });
 
-		this.history.save(options, ACTIONS.CHOOSE, lastOptionClose ?? false);
+        // Allow passing a result directly instead of prompting for it.
+        // Mostly used for testing without the need for interactive input
 
-		if (lastOptionClose && result === String(options.length - 1)) {
-			this.close();
-		}
+        let result: string;
+        if (preferences.choice !== undefined) {
+            result = this.cleanInput(this.coerceChoice(preferences.choice));
+        } else {
+            result = await this.read();
+        }
 
-		return options.map((_option: string, index: number) => {
-			if (result === String(index)) {
-				return true;
-			}
-			return false;
-		});
-	}
+        this.history.save(options, ACTIONS.CHOOSE, preferences.lastOptionClose ?? false);
 
-	/**
-	 * Prompts the user to answer a question
-	 * @param {string} question
-	 * @param {boolean} includeNewline Include a newline before asking for the input
-	 * @param {string | number} value value to auto-select
-	 * @returns {Promise<string>} The value entered
-	 */
-	public question = (question: string, includeNewline?: boolean, value?: string | number): Promise<string> => {
-		this.out.print(question, includeNewline ?? true);
+        if (preferences.lastOptionClose && result === String(options.length - 1)) {
+            this.close();
+        }
 
-		this.history.save(question, ACTIONS.QUESTION, undefined, includeNewline ?? true);
+        return options.map((_option: string, index: number) => {
+            if (result === String(index)) {
+                return true;
+            }
+            return false;
+        });
+    };
 
-		if (value) {
-			return this.promisify(this.cleanInput(this.coerceChoice(value)));
-		}
+    /**
+     * Prompts the user to answer a question
+     * @param {string} question
+     * @param {boolean} includeNewline Include a newline before asking for the input
+     * @param {string | number} value value to auto-select
+     * @returns {Promise<string>} The value entered
+     */
+    public question = (question: string, includeNewline?: boolean, value?: string | number): Promise<string> => {
+        this.out.print(question, includeNewline ?? true);
 
-		return this.read();
-	}
+        this.history.save(question, ACTIONS.QUESTION, undefined, includeNewline ?? true);
 
-	/**
-	 * Closes the loop
-	 */
-	public close = () => {
-		this.done = true;
-	}
+        if (value) {
+            return this.promisify(this.cleanInput(this.coerceChoice(value)));
+        }
+
+        return this.read();
+    };
+
+    /**
+     * Closes the loop
+     */
+    public close = () => {
+        this.done = true;
+    };
 }

--- a/index.ts
+++ b/index.ts
@@ -67,11 +67,10 @@ export default class InputLoop {
 	 */
 	public choose = async (options: string[], lastOptionClose?: boolean, choice?: string | number): Promise<boolean[]> => {
 		this.out.newline();
-		this.out.divider(30);
 		options.forEach((option: string, index: number) => {
-			this.out.print(`${index}: ${option}`, true);
+			if (options.length < 5) this.out.print(`[${index}] ${option}  `);
+			else this.out.print(`${index}: ${option}`, true);
 		});
-		this.out.divider(30);
 		
 		// Allow passing a result directly instead of prompting for it.
 		// Mostly used for testing without the need for interactive input

--- a/index.ts
+++ b/index.ts
@@ -68,7 +68,7 @@ export default class InputLoop {
 	public choose = async (options: string[], lastOptionClose?: boolean, choice?: string | number): Promise<boolean[]> => {
 		this.out.newline();
 		options.forEach((option: string, index: number) => {
-			if (options.length < 5) this.out.print(`[${index}] ${option}  `);
+			if (options.length < 7) this.out.print(`[${index}] ${option}  `);
 			else this.out.print(`${index}: ${option}`, true);
 		});
 		

--- a/install/input.ts
+++ b/install/input.ts
@@ -1,0 +1,358 @@
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+// This is a specialised implementation of a System module loader.
+
+// @ts-nocheck
+/* eslint-disable */
+let System, __instantiateAsync, __instantiate;
+
+(() => {
+  const r = new Map();
+
+  System = {
+    register(id, d, f) {
+      r.set(id, { d, f, exp: {} });
+    },
+  };
+
+  async function dI(mid, src) {
+    let id = mid.replace(/\.\w+$/i, "");
+    if (id.includes("./")) {
+      const [o, ...ia] = id.split("/").reverse(),
+        [, ...sa] = src.split("/").reverse(),
+        oa = [o];
+      let s = 0,
+        i;
+      while ((i = ia.shift())) {
+        if (i === "..") s++;
+        else if (i === ".") break;
+        else oa.push(i);
+      }
+      if (s < sa.length) oa.push(...sa.slice(s));
+      id = oa.reverse().join("/");
+    }
+    return r.has(id) ? gExpA(id) : import(mid);
+  }
+
+  function gC(id, main) {
+    return {
+      id,
+      import: (m) => dI(m, id),
+      meta: { url: id, main },
+    };
+  }
+
+  function gE(exp) {
+    return (id, v) => {
+      v = typeof id === "string" ? { [id]: v } : id;
+      for (const [id, value] of Object.entries(v)) {
+        Object.defineProperty(exp, id, {
+          value,
+          writable: true,
+          enumerable: true,
+        });
+      }
+    };
+  }
+
+  function rF(main) {
+    for (const [id, m] of r.entries()) {
+      const { f, exp } = m;
+      const { execute: e, setters: s } = f(gE(exp), gC(id, id === main));
+      delete m.f;
+      m.e = e;
+      m.s = s;
+    }
+  }
+
+  async function gExpA(id) {
+    if (!r.has(id)) return;
+    const m = r.get(id);
+    if (m.s) {
+      const { d, e, s } = m;
+      delete m.s;
+      delete m.e;
+      for (let i = 0; i < s.length; i++) s[i](await gExpA(d[i]));
+      const r = e();
+      if (r) await r;
+    }
+    return m.exp;
+  }
+
+  function gExp(id) {
+    if (!r.has(id)) return;
+    const m = r.get(id);
+    if (m.s) {
+      const { d, e, s } = m;
+      delete m.s;
+      delete m.e;
+      for (let i = 0; i < s.length; i++) s[i](gExp(d[i]));
+      e();
+    }
+    return m.exp;
+  }
+
+  __instantiateAsync = async (m) => {
+    System = __instantiateAsync = __instantiate = undefined;
+    rF(m);
+    return gExpA(m);
+  };
+
+  __instantiate = (m) => {
+    System = __instantiateAsync = __instantiate = undefined;
+    rF(m);
+    return gExp(m);
+  };
+})();
+
+System.register("types", [], function (exports_1, context_1) {
+  "use strict";
+  var ACTIONS;
+  var __moduleName = context_1 && context_1.id;
+  return {
+    setters: [],
+    execute: function () {
+      (function (ACTIONS) {
+        ACTIONS[ACTIONS["NONE"] = 0] = "NONE";
+        ACTIONS[ACTIONS["CHOOSE"] = 1] = "CHOOSE";
+        ACTIONS[ACTIONS["QUESTION"] = 2] = "QUESTION";
+      })(ACTIONS || (ACTIONS = {}));
+      exports_1("ACTIONS", ACTIONS);
+    },
+  };
+});
+System.register("printer", [], function (exports_2, context_2) {
+  "use strict";
+  var dividerChar, Printer;
+  var __moduleName = context_2 && context_2.id;
+  return {
+    setters: [],
+    execute: function () {
+      dividerChar = "-";
+      Printer = class Printer {
+        constructor(config) {
+          this.silent = false;
+          this.writeLine = (value, includeNewline) => {
+            if (!this.silent) {
+              const e = new TextEncoder().encode(
+                `${value}${includeNewline ? "\n" : ""}`,
+              );
+              Deno.stdout.writeSync(Uint8Array.from(e));
+            }
+          };
+          this.print = (value, includeNewline) => {
+            this.writeLine(value, includeNewline);
+          };
+          this.newline = () => {
+            this.writeLine("\n", false);
+          };
+          this.divider = (length = 10) => {
+            let outStr = "";
+            for (let i = 0; i < length; i++) {
+              outStr += dividerChar;
+            }
+            this.writeLine(outStr, true);
+          };
+          this.silent = config?.silent ?? false;
+        }
+      };
+      exports_2("default", Printer);
+    },
+  };
+});
+System.register("history", ["types"], function (exports_3, context_3) {
+  "use strict";
+  var types_ts_1, History;
+  var __moduleName = context_3 && context_3.id;
+  return {
+    setters: [
+      function (types_ts_1_1) {
+        types_ts_1 = types_ts_1_1;
+      },
+    ],
+    execute: function () {
+      History = class History {
+        constructor() {
+          this.last = {
+            argument: "",
+            lastOptionClose: false,
+            action: types_ts_1.ACTIONS.NONE,
+            includeNewline: false,
+          };
+          this.save = (argument, action, lastOptionClose, includeNewline) => {
+            this.last = {
+              argument,
+              lastOptionClose: lastOptionClose ?? this.last.lastOptionClose,
+              includeNewline: includeNewline ?? this.last.includeNewline,
+              action,
+            };
+          };
+          this.retrieve = () => {
+            return this.last;
+          };
+        }
+      };
+      exports_3("default", History);
+    },
+  };
+});
+System.register(
+  "index",
+  ["types", "printer", "history"],
+  function (exports_4, context_4) {
+    "use strict";
+    var types_ts_2, printer_ts_1, history_ts_1, InputLoop;
+    var __moduleName = context_4 && context_4.id;
+    return {
+      setters: [
+        function (types_ts_2_1) {
+          types_ts_2 = types_ts_2_1;
+        },
+        function (printer_ts_1_1) {
+          printer_ts_1 = printer_ts_1_1;
+        },
+        function (history_ts_1_1) {
+          history_ts_1 = history_ts_1_1;
+        },
+      ],
+      execute: function () {
+        InputLoop = class InputLoop {
+          constructor(args) {
+            this.buf = new Uint8Array(1024);
+            this.done = false;
+            this.out = new printer_ts_1.default();
+            this.history = new history_ts_1.default();
+            this.coerceChoice = (value) => {
+              if (typeof value === "number") {
+                return String(value);
+              }
+              return value;
+            };
+            this.promisify = (value) => {
+              return new Promise((resolve) => resolve(value));
+            };
+            this.cleanInput = (value) => {
+              return value?.replace("\n", "").replace("\r", "") ?? "";
+            };
+            /**
+                     * Repeats the last prompt
+                     * @param {string | number} value value to auto-select
+                     */
+            this.repeat = (value) => {
+              if (this.history.retrieve().action) {
+                if (
+                  this.history.retrieve().action === types_ts_2.ACTIONS.CHOOSE
+                ) {
+                  return this.choose(
+                    this.history.retrieve().argument,
+                    this.history.retrieve().lastOptionClose,
+                    value,
+                  );
+                }
+                if (
+                  this.history.retrieve().action === types_ts_2.ACTIONS.QUESTION
+                ) {
+                  return this.question(
+                    this.history.retrieve().argument,
+                    this.history.retrieve().includeNewline,
+                    value,
+                  );
+                }
+              }
+            };
+            /**
+                     * Read input from the console
+                     * @returns {Promise<string>} The value read
+                     */
+            this.read = async () => {
+              return new Promise(async (resolve, reject) => {
+                const n = await Deno.stdin.read(this.buf);
+                if (n) {
+                  resolve(
+                    this.cleanInput(
+                      new TextDecoder().decode(this.buf.subarray(0, n)),
+                    ),
+                  );
+                } else {
+                  reject();
+                }
+              });
+            };
+            /**
+                     * Prompts the user to choose from a list of options
+                     * @param {string[]} options
+                     * @param {boolean} lastOptionClose Whether selecting the last option in the list should close the loop
+                     * @param {string | number} choice value to auto-select
+                     * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
+                     */
+            this.choose = async (options, lastOptionClose, choice) => {
+              this.out.newline();
+              options.forEach((option, index) => {
+                if (options.length < 5) {
+                  this.out.print(`[${index}] ${option}  `);
+                } else {
+                  this.out.print(`${index}: ${option}`, true);
+                }
+              });
+              // Allow passing a result directly instead of prompting for it.
+              // Mostly used for testing without the need for interactive input
+              let result;
+              if (choice !== undefined) {
+                result = this.cleanInput(this.coerceChoice(choice));
+              } else {
+                result = await this.read();
+              }
+              this.history.save(
+                options,
+                types_ts_2.ACTIONS.CHOOSE,
+                lastOptionClose ?? false,
+              );
+              if (lastOptionClose && result === String(options.length - 1)) {
+                this.close();
+              }
+              return options.map((_option, index) => {
+                if (result === String(index)) {
+                  return true;
+                }
+                return false;
+              });
+            };
+            /**
+                     * Prompts the user to answer a question
+                     * @param {string} question
+                     * @param {boolean} includeNewline Include a newline before asking for the input
+                     * @param {string | number} value value to auto-select
+                     * @returns {Promise<string>} The value entered
+                     */
+            this.question = (question, includeNewline, value) => {
+              this.out.print(question, includeNewline ?? true);
+              this.history.save(
+                question,
+                types_ts_2.ACTIONS.QUESTION,
+                undefined,
+                includeNewline ?? true,
+              );
+              if (value) {
+                return this.promisify(
+                  this.cleanInput(this.coerceChoice(value)),
+                );
+              }
+              return this.read();
+            };
+            /**
+                     * Closes the loop
+                     */
+            this.close = () => {
+              this.done = true;
+            };
+            this.out = new printer_ts_1.default(args);
+          }
+        };
+        exports_4("default", InputLoop);
+      },
+    };
+  },
+);
+
+const __exp = __instantiate("index");
+export default __exp["default"];

--- a/install/input.ts
+++ b/install/input.ts
@@ -123,12 +123,11 @@ System.register("types", [], function (exports_1, context_1) {
 });
 System.register("printer", [], function (exports_2, context_2) {
   "use strict";
-  var dividerChar, Printer;
+  var Printer;
   var __moduleName = context_2 && context_2.id;
   return {
     setters: [],
     execute: function () {
-      dividerChar = "-";
       Printer = class Printer {
         constructor(config) {
           this.silent = false;
@@ -146,7 +145,7 @@ System.register("printer", [], function (exports_2, context_2) {
           this.newline = () => {
             this.writeLine("\n", false);
           };
-          this.divider = (length = 10) => {
+          this.divider = (length = 10, dividerChar = "-") => {
             let outStr = "";
             for (let i = 0; i < length; i++) {
               outStr += dividerChar;
@@ -243,11 +242,10 @@ System.register(
                 if (
                   this.history.retrieve().action === types_ts_2.ACTIONS.CHOOSE
                 ) {
-                  return this.choose(
-                    this.history.retrieve().argument,
-                    this.history.retrieve().lastOptionClose,
-                    value,
-                  );
+                  return this.choose(this.history.retrieve().argument, {
+                    lastOptionClose: this.history.retrieve().lastOptionClose,
+                    choice: value,
+                  });
                 }
                 if (
                   this.history.retrieve().action === types_ts_2.ACTIONS.QUESTION
@@ -285,15 +283,66 @@ System.register(
                      * @param {string | number} choice value to auto-select
                      * @returns {Promise<boolean[]>} An array of booleans representing which index was selected
                      */
-            this.choose = async (options, lastOptionClose, choice) => {
+            this.choose = async (options, preferences = {}) => {
+              let {
+                choice,
+                lastOptionClose,
+                displayInline,
+                inlineSpacing,
+                inlineSeparator,
+                indexStyle,
+                dividerTop,
+                dividerBottom,
+                dividerChar,
+                dividerLength,
+                dividerPadding,
+              } = preferences;
+              // Index Styling
+              let indexStyleLeft = "[";
+              let indexStyleRight = "]";
+              if (indexStyle) {
+                indexStyleLeft = indexStyle[0];
+                indexStyleRight = indexStyle[1];
+              }
+              // Spacing
               this.out.newline();
+              // Divider Up
+              if (dividerTop) {
+                this.out.divider(
+                  dividerLength || undefined,
+                  dividerChar || undefined,
+                );
+              }
+              if (dividerPadding) {
+                this.out.newline();
+              }
+              // Separator
+              let separator = inlineSeparator ? ` ${inlineSeparator} `
+              : " ".repeat(inlineSpacing || 2);
+              // Options
               options.forEach((option, index) => {
-                if (options.length < 5) {
-                  this.out.print(`[${index}] ${option}  `);
+                if (displayInline) {
+                  this.out.print(
+                    `${indexStyleLeft}${index}${indexStyleRight} ${option}${separator}`,
+                  );
                 } else {
-                  this.out.print(`${index}: ${option}`, true);
+                  this.out.print(
+                    `${indexStyleLeft}${index}${indexStyleRight} ${option}`,
+                    true,
+                  );
                 }
               });
+              // Divider Bottom
+              if (dividerBottom) {
+                this.out.newline();
+                if (dividerPadding) {
+                  this.out.newline();
+                }
+                this.out.divider(
+                  dividerLength || undefined,
+                  dividerChar || undefined,
+                );
+              }
               // Allow passing a result directly instead of prompting for it.
               // Mostly used for testing without the need for interactive input
               let result;

--- a/printer.ts
+++ b/printer.ts
@@ -1,7 +1,5 @@
 import { IConfig } from "./types.ts";
 
-const dividerChar = '-';
-
 export default class Printer {
 	silent = false;
 
@@ -24,7 +22,7 @@ export default class Printer {
 		this.writeLine('\n', false);
 	}
 
-	public divider = (length: number = 10) => {
+	public divider = (length: number = 10, dividerChar: string = '-') => {
 		let outStr = '';
 
 		for (let i = 0; i < length; i++) {

--- a/types.ts
+++ b/types.ts
@@ -14,3 +14,19 @@ export interface ILastAction {
 	action: ACTIONS;
 	includeNewline: boolean;
 }
+
+export interface Preferences {
+	lastOptionClose?: boolean,
+	choice?: string | number,
+	
+	// Breakpoint
+	breakPoint?: number,
+	
+	// Index
+	indexStyle?: string,
+	
+	// Divider
+	dividerUp?: boolean,
+	dividerBottom?: boolean
+	dividerStyle?: string
+}

--- a/types.ts
+++ b/types.ts
@@ -18,15 +18,12 @@ export interface ILastAction {
 export interface Preferences {
 	lastOptionClose?: boolean,
 	choice?: string | number,
-	
-	// Breakpoint
-	breakPoint?: number,
-	
-	// Index
-	indexStyle?: string,
-	
-	// Divider
-	dividerUp?: boolean,
+	displayInline?: boolean,
+	inlineSpacing?: number,
+	indexStyle?: string[],
+	dividerTop?: boolean,
 	dividerBottom?: boolean
-	dividerStyle?: string
+	dividerLength?: number
+	dividerChar?: string,
+	dividerPadding?: boolean
 }

--- a/types.ts
+++ b/types.ts
@@ -19,6 +19,7 @@ export interface Preferences {
 	lastOptionClose?: boolean,
 	choice?: string | number,
 	displayInline?: boolean,
+	inlineSeparator?: string
 	inlineSpacing?: number,
 	indexStyle?: string[],
 	dividerTop?: boolean,


### PR DESCRIPTION
Changes: 
1. choose() now takes an optional preferences object instead of the 2 optional parameters. (they're now included in the object among other options).
2. Ability to display options in the same line.
3. Ability to set a separator of choice between inline options.
4. Ability to set custom spacing between inline options.
5. It is now possible to change the "styling" of the index. and what to display around it.
6. Dividers are removed by default, can be activated separately (top and bottom).
7. Ability to set dividers length from the preferences object, and the dividerChar as well.
8. Option to add or remove the spacing (new line) between the dividers and the options.

Extras:
1. Updated the tests so they work with new way of passing parameters to choose()
2. Readme is updated with everything explained
3. Added a Usage section in the Readme, and bundled everything in one file hosted in github for ease of access. (under /install
