### PR TITLE
Private Input (Hidden as You Type)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
 test:
 	deno test index.test.ts
 	deno test history.test.ts
+
+cli:
+	deno run cli.ts
+
+cli-unstable:
+	deno run --unstable cli.ts

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ while (!(result[0] || result[1])) {
 
 ```
 
+## Experimental
+In order to use private input (not visible as you type), use the `--unstable` flag when running, and you can pass a flag to `read` or `question` to enable it:
+```javascript
+const input = new InputLoop();
+const mainQuestions = ["Add a node", "Add an edge", "Set starting node", "Evaluate a string", "Quit"];
+
+let result = await input.choose(mainQuestions, false, true);
+
+while (!(result[0] || result[1])) {
+	result = input.repeat();
+}
+```
+
 ## Testing
 Deno tests can be run using:
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ while (!(result[0] || result[1])) {
 ```
 
 ## Experimental
-In order to use private input (not visible as you type), use the `--unstable` flag when running, and you can pass a flag to `read` or `question` to enable it:
+In order to use private input (not visible as you type), use the `--unstable` flag when running, and you can pass a flag to `choose` or `question` to enable it:
 ```javascript
 const input = new InputLoop();
 const mainQuestions = ["Add a node", "Add an edge", "Set starting node", "Evaluate a string", "Quit"];

--- a/cli.ts
+++ b/cli.ts
@@ -3,6 +3,19 @@ import Input from './index.ts';
 const input = new Input();
 
 while (!input.done) {
-	await input.question("Say something: ", false);
-	await input.question("Say something with newline:");
+	const result1 = await input.question("Say something: ", false);
+	console.log('You said', result1);
+	const result2 = await input.question("Say something with newline:");
+	console.log('You said', result2);
+	const result3 = await input.question("Say something secret:", false, true);
+	console.log('You said', result3);
+	const result3b = await input.repeat();
+	console.log('You said again', result3b);
+	const result4 = await input.choose(["Option A", "Option B"], false);
+	console.log('You chose', result4);
+	const result5 = await input.choose(["Option A Private", "Option B Private"], false, true);
+	console.log('You chose', result5);
+	await input.choose(["Continue", "Quit"], true);
 }
+
+Deno.exit();

--- a/history.test.ts
+++ b/history.test.ts
@@ -10,21 +10,52 @@ Deno.test("Initialize successfully", () => {
 Deno.test("Get default history", () => {
   const history = new History();
   const result = history.retrieve();
-  assertEquals(result, { argument: '', lastOptionClose: false, action: ACTIONS.NONE, includeNewline: false });
+  assertEquals(result, {
+	  argument: '',
+	  lastOptionClose: false,
+	  action: ACTIONS.NONE,
+	  includeNewline: false,
+	  privateInput: false,
+	});
 });
 
 Deno.test("Save history (question)", () => {
   const history = new History();
   history.save('Hello, World!', ACTIONS.QUESTION);
   const result = history.retrieve();
-  assertEquals(result, { argument: 'Hello, World!', lastOptionClose: false, action: ACTIONS.QUESTION, includeNewline: false });
+  assertEquals(result, {
+	  argument: 'Hello, World!',
+	  lastOptionClose: false,
+	  action: ACTIONS.QUESTION,
+	  includeNewline: false,
+	  privateInput: false,
+	});
 });
 
-Deno.test("Save history (question | newLine)", () => {
+Deno.test("Save history (question) (privateInput)", () => {
+	const history = new History();
+	history.save('Hello, World!', ACTIONS.QUESTION, undefined, undefined, true);
+	const result = history.retrieve();
+	assertEquals(result, {
+		argument: 'Hello, World!',
+		lastOptionClose: false,
+		action: ACTIONS.QUESTION,
+		includeNewline: false,
+		privateInput: true,
+	});
+});
+
+Deno.test("Save history (question) (newLine)", () => {
   const history = new History();
   history.save('Hello, World!', ACTIONS.QUESTION, undefined, true);
   const result = history.retrieve();
-  assertEquals(result, { argument: 'Hello, World!', lastOptionClose: false, action: ACTIONS.QUESTION, includeNewline: true });
+  assertEquals(result, {
+	  argument: 'Hello, World!',
+	  lastOptionClose: false,
+	  action: ACTIONS.QUESTION,
+	  includeNewline: true,
+	  privateInput: false,
+	});
 });
 
 Deno.test("Save history (choose)", () => {
@@ -32,7 +63,13 @@ Deno.test("Save history (choose)", () => {
   const options = ["Hello, World!", "Goodbye!"];
   history.save(['Hello, World!', 'Goodbye!'], ACTIONS.CHOOSE, false);
   const result = history.retrieve();
-  assertEquals(result, { argument: options, lastOptionClose: false, action: ACTIONS.CHOOSE, includeNewline: false });
+  assertEquals(result, {
+	  argument: options,
+	  lastOptionClose: false,
+	  action: ACTIONS.CHOOSE,
+	  includeNewline: false,
+	  privateInput: false,
+	});
 });
 
 Deno.test("Save history (choose) (autoLoop)", () => {
@@ -40,5 +77,11 @@ Deno.test("Save history (choose) (autoLoop)", () => {
   const options = ["Hello, World!", "Goodbye!"];
   history.save(['Hello, World!', 'Goodbye!'], ACTIONS.CHOOSE, true);
   const result = history.retrieve();
-  assertEquals(result, { argument: options, lastOptionClose: true, action: ACTIONS.CHOOSE, includeNewline: false });
+  assertEquals(result, {
+	  argument: options,
+	  lastOptionClose: true,
+	  action: ACTIONS.CHOOSE,
+	  includeNewline: false,
+	  privateInput: false,
+	});
 });

--- a/history.ts
+++ b/history.ts
@@ -6,13 +6,15 @@ export default class History {
 		lastOptionClose: false,
 		action: ACTIONS.NONE,
 		includeNewline: false,
+		privateInput: false,
 	};
 
-	public save = (argument: string | string[], action: ACTIONS, lastOptionClose?: boolean, includeNewline?: boolean) => {
+	public save = (argument: string | string[], action: ACTIONS, lastOptionClose?: boolean, includeNewline?: boolean, privateInput?: boolean) => {
 		this.last = {
 			argument,
 			lastOptionClose: lastOptionClose ?? this.last.lastOptionClose,
 			includeNewline: includeNewline ?? this.last.includeNewline,
+			privateInput: privateInput ?? this.last.privateInput,
 			action,
 		}
 	}

--- a/index.test.ts
+++ b/index.test.ts
@@ -25,15 +25,31 @@ Deno.test("Should choose an answer (number)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 2);
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, 2);
   assertEquals(result, [false, false, true]);
+});
+
+Deno.test("Should choose an answer (number) (privateInput)", async () => {
+	const loop = new inputLoop({
+		silent: true,
+	});
+	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, true, 2);
+	assertEquals(result, [false, false, true]);
+});
+
+Deno.test("Should choose an answer (number) (privateInput explicitly false)", async () => {
+	const loop = new inputLoop({
+		silent: true,
+	});
+	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, false, 2);
+	assertEquals(result, [false, false, true]);
 });
 
 Deno.test("Should choose an answer (string)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2');
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, '2');
   assertEquals(result, [false, false, true]);
 });
 
@@ -42,7 +58,7 @@ Deno.test("Should choose an answer (string | CRLF) ", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2\r\n');
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, '2\r\n');
   assertEquals(result, [false, false, true]);
 });
 
@@ -50,7 +66,7 @@ Deno.test("Should not choose an answer (number)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 3);
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, 3);
   assertEquals(result, [false, false, false]);
 });
 
@@ -58,7 +74,7 @@ Deno.test("Should not choose an answer (string)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '3');
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, '3');
   assertEquals(result, [false, false, false]);
 });
 
@@ -66,7 +82,7 @@ Deno.test("Should run repeat on choose success (number)", async () => {
   const loop = new inputLoop({
 	silent: true,
 	});
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 2);
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, 2);
   assertEquals(result, [false, false, true]);
   const result2 = await loop.repeat(2);
   assertEquals(result2, [false, false, true]);
@@ -76,7 +92,7 @@ Deno.test("Should run repeat on choose success (string)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, '2');
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, '2');
   assertEquals(result, [false, false, true]);
   const result2 = await loop.repeat('2');
   assertEquals(result2, [false, false, true]);
@@ -86,7 +102,7 @@ Deno.test("Should run repeat on choose fail (number)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, 3);
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, 3);
   assertEquals(result, [false, false, false]);
   const result2 = await loop.repeat(3);
   assertEquals(result2, [false, false, false]);
@@ -96,7 +112,7 @@ Deno.test("Should run repeat on choose fail (string)", async () => {
   const loop = new inputLoop({
 	  silent: true,
   });
-  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, "3");
+  const result = await loop.choose(["Option 1", "Option 2", "Option 3"], false, undefined, "3");
   assertEquals(result, [false, false, false]);
   const result2 = await loop.repeat("3");
   assertEquals(result2, [false, false, false]);
@@ -106,7 +122,7 @@ Deno.test("Should answer a question (number)", async () => {
   const loop = new inputLoop({
     silent: true,
   });
-  const result = await loop.question("Please answer the question", true, 2);
+  const result = await loop.question("Please answer the question", true, undefined, 2);
   assertEquals(result, '2');
 });
 
@@ -114,7 +130,7 @@ Deno.test("Should answer a question (string)", async () => {
   const loop = new inputLoop({
     silent: true,
   });
-  const result = await loop.question("Please answer the question", true, "Hello!");
+  const result = await loop.question("Please answer the question", true, undefined, "Hello!");
   assertEquals(result, "Hello!");
 });
 
@@ -122,7 +138,7 @@ Deno.test("Should answer a question (string | no newline)", async () => {
   const loop = new inputLoop({
     silent: true,
   });
-  const result = await loop.question("Please answer the question", false, "Hello!");
+  const result = await loop.question("Please answer the question", false, undefined, "Hello!");
   assertEquals(result, "Hello!");
 });
 
@@ -130,7 +146,7 @@ Deno.test("Should run repeat on question (string)", async () => {
   const loop = new inputLoop({
     silent: true,
   });
-  const result = await loop.question("Please answer the question", true, "Hello!");
+  const result = await loop.question("Please answer the question", true, undefined, "Hello!");
   assertEquals(result, "Hello!");
   const result2 = await loop.repeat("Hello Again!");
   assertEquals(result2, 'Hello Again!')
@@ -141,7 +157,7 @@ Deno.test("Should close automatically (string)", async () => {
 		silent: true,
 	});
 	assertEquals(loop.done, false);
-	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, "2");
+	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, undefined, "2");
 	assertEquals(result, [false, false, true]);
 	assertEquals(loop.done, true);
 });
@@ -151,7 +167,7 @@ Deno.test("Should close automatically (number)", async () => {
 		silent: true,
 	});
 	assertEquals(loop.done, false);
-	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, 2);
+	const result = await loop.choose(["Option 1", "Option 2", "Option 3"], true, undefined, 2);
 	assertEquals(result, [false, false, true]);
 	assertEquals(loop.done, true);
 });

--- a/index.ts
+++ b/index.ts
@@ -32,12 +32,13 @@ export default class InputLoop {
 	 * @param {string | number} value value to auto-select
 	 */
 	public repeat = (value?: string | number) => {
-		if (this.history.retrieve().action) {
-			if (this.history.retrieve().action === ACTIONS.CHOOSE) {
-				return this.choose(this.history.retrieve().argument as string[], this.history.retrieve().lastOptionClose, value);
+		const retrievedHistory = this.history.retrieve();
+		if (retrievedHistory.action) {
+			if (retrievedHistory.action === ACTIONS.CHOOSE) {
+				return this.choose(retrievedHistory.argument as string[], retrievedHistory.lastOptionClose, retrievedHistory.privateInput, value);
 			}
-			if (this.history.retrieve().action === ACTIONS.QUESTION) {
-				return this.question(this.history.retrieve().argument as string, this.history.retrieve().includeNewline, value);
+			if (retrievedHistory.action === ACTIONS.QUESTION) {
+				return this.question(retrievedHistory.argument as string, retrievedHistory.includeNewline, retrievedHistory.privateInput, value);
 			}
 		}
 	}
@@ -111,7 +112,7 @@ export default class InputLoop {
 			result = await this.read(privateInput ?? false);
 		}
 
-		this.history.save(options, ACTIONS.CHOOSE, lastOptionClose ?? false);
+		this.history.save(options, ACTIONS.CHOOSE, lastOptionClose ?? false, undefined, privateInput ?? false);
 
 		if (lastOptionClose && result === String(options.length - 1)) {
 			this.close();
@@ -136,7 +137,7 @@ export default class InputLoop {
 	public question = (question: string, includeNewline?: boolean, privateInput?: boolean, value?: string | number): Promise<string> => {
 		this.out.print(question, includeNewline ?? true);
 
-		this.history.save(question, ACTIONS.QUESTION, undefined, includeNewline ?? true);
+		this.history.save(question, ACTIONS.QUESTION, undefined, includeNewline ?? true, privateInput ?? false);
 
 		if (value) {
 			return this.promisify(this.cleanInput(this.coerceChoice(value)));

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
-import { IConfig, ACTIONS } from './types.ts';
+import { ACTIONS } from './types.ts';
+import type { IConfig } from './types.ts';
 import Printer from './printer.ts';
 import History from './history.ts';
 
@@ -50,7 +51,9 @@ export default class InputLoop {
 	 */
 	public read = async (privateInput: boolean): Promise<string> => {
 		if (privateInput) {
-			return this.readPrivate();
+			const result = await this.readPrivate();
+			this.out.newline();
+			return result;
 		}
 		return new Promise(async (resolve, reject) => {
 			const n = await Deno.stdin.read(this.buf);
@@ -113,7 +116,7 @@ export default class InputLoop {
 		}
 
 		this.history.save(options, ACTIONS.CHOOSE, lastOptionClose ?? false, undefined, privateInput ?? false);
-
+		console.log(lastOptionClose, result === String(options.length - 1));
 		if (lastOptionClose && result === String(options.length - 1)) {
 			this.close();
 		}

--- a/printer.ts
+++ b/printer.ts
@@ -1,4 +1,4 @@
-import { IConfig } from "./types.ts";
+import type { IConfig } from "./types.ts";
 
 const dividerChar = '-';
 

--- a/types.ts
+++ b/types.ts
@@ -13,4 +13,5 @@ export interface ILastAction {
 	lastOptionClose: boolean;
 	action: ACTIONS;
 	includeNewline: boolean;
+	privateInput: boolean;
 }


### PR DESCRIPTION
This PR add support for private input. In order for it to work, the --unstable flag needs to be set, however if it's not set the library will fail gracefully and fall back on non-private input.

Closes #9 