### PR TITLE
Fix async read closes #21

### DIFF
--- a/.github/workflows/history.yml
+++ b/.github/workflows/history.yml
@@ -14,5 +14,5 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: v1.4.2
+        deno-version: v1.15.3
     - run: deno test history.test.ts

--- a/.github/workflows/input.yml
+++ b/.github/workflows/input.yml
@@ -14,5 +14,5 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: v1.4.2
+        deno-version: v1.15.3
     - run: deno test index.test.ts

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ while (!(result[0] || result[1])) {
 }
 ```
 
+This is also required for `input.wait()`, which can be used to wait for any key to be pressed:
+
+```javascript
+await input.wait('Press any key to continue...', true);
+
+// Equivalent to
+await input.wait();
+```
+
 ## Testing
 Deno tests can be run using:
 ```

--- a/cli.ts
+++ b/cli.ts
@@ -3,6 +3,7 @@ import Input from './index.ts';
 const input = new Input();
 
 while (!input.done) {
+	await input.wait();
 	const result1 = await input.question("Say something: ", false);
 	console.log('You said', result1);
 	const result2 = await input.question("Say something with newline:");

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,8 @@ export default class InputLoop {
 				break;
 			}
 			if (text.includes('\u0003') || text.includes('\u0004')) {
+				(Deno as any).setRaw?.(Deno.stdin.rid, false);
+				p.resolve('');
 				Deno.exit();
 			}
 			input += text;

--- a/index.ts
+++ b/index.ts
@@ -89,6 +89,23 @@ export default class InputLoop {
 		return p;
 	}
 
+	public wait = async (question?: string, includeNewline?: boolean): Promise<boolean> => {
+		this.out.print(question ?? 'Press any key to continue...', includeNewline ?? true);
+		(Deno as any).setRaw?.(Deno.stdin.rid, true);
+		const p = deferred<boolean>();
+
+		let n = await Deno.stdin.read(this.buf);
+
+		if (n) {
+			(Deno as any).setRaw?.(Deno.stdin.rid, false);
+			p.resolve(true);
+		} else {
+			p.resolve(false);
+		}
+
+		return p;
+	}
+
 	/**
 	 * Prompts the user to choose from a list of options
 	 * @param {string[]} options


### PR DESCRIPTION
Adds a `wait` method behind the `--unstable` flag to prompt for the user to press any key to continue. 

This also fixes a critical bug with private input handling.