### PR TITLE
(Deno as any).setRaw changed to (Deno as any).stdin.setRaw

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ export default class InputLoop {
 	}
 
 	private readPrivate = async (): Promise<string> => {
-		(Deno as any).setRaw?.(Deno.stdin.rid, true);
+		(Deno as any).stdin.setRaw?.(Deno.stdin.rid, true);
 		const p = deferred<string>();
 		let input = '';
 
@@ -73,12 +73,12 @@ export default class InputLoop {
 		while (n) {
 			const text = new TextDecoder().decode(this.buf.subarray(0, n));
 			if (text.includes('\n') || text.includes('\r')) {
-				(Deno as any).setRaw?.(Deno.stdin.rid, false);
+				(Deno as any).stdin.setRaw?.(Deno.stdin.rid, false);
 				p.resolve(input);
 				break;
 			}
 			if (text.includes('\u0003') || text.includes('\u0004')) {
-				(Deno as any).setRaw?.(Deno.stdin.rid, false);
+				(Deno as any).stdin.setRaw?.(Deno.stdin.rid, false);
 				p.resolve('');
 				Deno.exit();
 			}
@@ -91,13 +91,13 @@ export default class InputLoop {
 
 	public wait = async (question?: string, includeNewline?: boolean): Promise<boolean> => {
 		this.out.print(question ?? 'Press any key to continue...', includeNewline ?? true);
-		(Deno as any).setRaw?.(Deno.stdin.rid, true);
+		(Deno as any).stdin.setRaw?.(Deno.stdin.rid, true);
 		const p = deferred<boolean>();
 
 		let n = await Deno.stdin.read(this.buf);
 
 		if (n) {
-			(Deno as any).setRaw?.(Deno.stdin.rid, false);
+			(Deno as any).stdin.setRaw?.(Deno.stdin.rid, false);
 			p.resolve(true);
 		} else {
 			p.resolve(false);


### PR DESCRIPTION
Deno.setRaw will throw an error as of Deno 1.26.0

https://github.com/denoland/deno/pull/15797

 I simply updated to Deno.stdin.setRaw.

This change was labelled (unstable) but was merged back on Sept. 28, Deno.setRaw now throws `Deno.setRaw is not a function` Please correct me if I'm wrong in assuming these needed to be updated.